### PR TITLE
Bug Fix #277

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -55,6 +55,11 @@ button {
   align-items: center;
   cursor: pointer;
 }
+
+.hover {
+  cursor: pointer;
+}
+
 #google_translate_element {
   position: absolute;
   top: 10px;

--- a/index.html
+++ b/index.html
@@ -130,7 +130,7 @@
       <div class="pop-up" style="display: none">
         <div class="upper-cross" style="padding: 4px">
           <button onclick="cross()">
-            <i class="fa-solid fa-xmark fa-beat" style="color: white"></i>
+            <i class="fa-solid fa-xmark fa-beat hover" style="color: white"></i>
           </button>
         </div>
         <div class="lower-content">
@@ -139,7 +139,7 @@
         </div>
         <div class="lower-button">
           <button onclick="nextSpeech()">
-            <i class="fa-solid fa-forward fa-bounce fa-lg"></i>
+            <i class="fa-solid fa-forward fa-bounce fa-lg hover"></i>
           </button>
         </div>
       </div>


### PR DESCRIPTION
Hover Effect Fix Properly on Welcome Popup Buttons

Fix #277 

When starting the game for the first time, a welcome popup appears with greetings and instructions on how to play the game. The popup includes a close button and a skip button icon. Earlier when we were hovering on both the buttons the pointer was not changing but now after the fix it is changing. For reference I have attached the video.


https://github.com/user-attachments/assets/ab911968-df5a-4da1-bc5a-7599e86ddc56

Fixes #277 