### PR TITLE
fix#283/welcome message is now visible

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -103,6 +103,7 @@ button {
 
 #speech-text {
   font-size: 17px;
+  color: #000;
 }
 
 #forge {


### PR DESCRIPTION
Welcome message fix and is now visible.

Fix #283 

When starting the site and after clicking on start button a dialogue box appears with some message but due to some reasons the message was not visible but after this fix it is now visible
For reference I have attached the video.

https://github.com/user-attachments/assets/91276d77-8cd2-417b-9540-2f5eca937d74

Fixes #283 